### PR TITLE
Fix missing endian.h error on Cygwin

### DIFF
--- a/eschalot.c
+++ b/eschalot.c
@@ -41,7 +41,7 @@
   #define le64toh(x) OSSwapLittleToHostInt64(x)
 #endif  /* __APPLE__ */
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__CYGWIN__)
 # define _GNU_SOURCE
 # include <endian.h>
 #endif


### PR DESCRIPTION
When compiling in Cygwin environment, no version of `endian.h` gets included, resulting in compilation errors. This is a simple, one-line fix.