### PR TITLE
Use RSA_generate_key_ex for OpenSSL >= 0.9.0.8

### DIFF
--- a/eschalot.c
+++ b/eschalot.c
@@ -68,6 +68,7 @@
 #include <openssl/rsa.h>
 #include <openssl/sha.h>
 #define OPENSSL_VERSION_1_1 0x10100000L
+#define OPENSSL_VERSION_0_9_0_8 0x0090800FL
 
 /* Define NEED_HTOBE32 if htobe32() is not available on your platform. */
 /* #define NEED_HTOBE32 */
@@ -263,7 +264,7 @@ worker(void *arg)
 
 	while (!done) {
 		/* Generate a new RSA key every time e reaches RSA_E_LIMIT */
-#if OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_1_1
+#if OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_0_9_0_8
 		rsa = RSA_new();
 		if (!RSA_generate_key_ex(rsa, RSA_KEYS_BITLEN, big_e, NULL))
 			error("RSA Key Generation failed!\n");


### PR DESCRIPTION
Older versions of OpenSSL used RSA_generate_key and newer versions use RSA_generate_key_ex . A change in 1a3a279 caused only versions of OpenSSL >= 1.1 to use the _ex form. This fails on, at least, openssl-1.0.2k-8, currently shipping on CentOS/RHEL during "make test" with a failure to create an RSA key.

This commit adds a test for OpenSSL >= 0.9.0.8 (release) and uses the _ex form there.  "make test" works with this change on openssl-1.0.2k-8 on EL7 and openssl-1.1.0f-7 on Fedora 26.

Resolves: #16