### PR TITLE
implement circular mode

### DIFF
--- a/README
+++ b/README
@@ -160,6 +160,12 @@ redirecting the results to a file:
 
 	$ ./eschalot -vct6 -l8-10 -f wordlist.txt >> results.txt
 
+There's a new search mode yielding quite good results: circular mode. In this
+mode, the dictionary is loaded into memory and all possible concatenations
+are tried up to the value of the -z parameter.
+
+    $ ./eschalot -vct6 -l2-16 -z 11 -f top1000.txt >> results.txt
+
 
 
 Generating a wordlist:


### PR DESCRIPTION
This patch implements circular mode for pattern searching. The mode is kind of like combining worgen with eschalot, but doesn't need extra diskspace. It brings some quite nice yields. Example:

    $ ./eschalot -cvt4 -l2-16 -z11 -f top1000.txt
    noworeacheihxhym.onion
    showjobhotapv5ov.onion
    nowholedealtji5f.onion
    fourtoandahwsxi2.onion
    tosoontoweaox2w7.onion
    medosilentppw234.onion
    skyfastmyglssuj5.onion
    uponeboxfir3z4k4.onion

Let's take nowholedealtji5f.onion as an example. It got constructed from a 11-character long prefix, which itself got composed from concatenated words from the dictionary: no, whole, deal. The last word can be cut, like in the example: uponeboxfir3z4k4.onion.