### PR TITLE
Refactor typecard.

### DIFF
--- a/typecard.c
+++ b/typecard.c
@@ -17,65 +17,78 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <ctype.h>
-#include <inttypes.h>
+#include <limits.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
 
-int
-main(int argc, char *argv[]) {
-	printf("\n");
-#ifdef __LP64__
-        printf("System: 64 bit\n");
+
+/* Check Endianness */
+#if   __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#	define ENDIAN_TYPE "Little"
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#	define ENDIAN_TYPE "Big"
+#elif __BYTE_ORDER__ == __ORDER_PDP_ENDIAN__
+#	define ENDIAN_TYPE "PDP"
 #else
-        printf("System: 32 bit\n");
+#	define ENDIAN_TYPE "Unknown"
 #endif
 
-#if BYTE_ORDER == BIG_ENDIAN
-        printf("Host byte order: Big Endian\n");
-#endif
-#if BYTE_ORDER == LITTLE_ENDIAN
-        printf("Host byte order: Little Endian\n");
-#endif
-	printf("\n");
-	printf("char:\t\t%2d (%3d bits)\n", sizeof(char), sizeof(char) * 8);
-	printf("short:\t\t%2d (%3d bits)\n", sizeof(short), sizeof(short) * 8);
-	printf("int:\t\t%2d (%3d bits)\n", sizeof(int), sizeof(int) * 8);
-	printf("long:\t\t%2d (%3d bits)\n", sizeof(long), sizeof(long) * 8);
-	printf("long long:\t%2d (%3d bits)\n", sizeof(long long), sizeof(long long) * 8);
-	printf("\n");
 
-	printf("float:\t\t%2d (%3d bits)\n", sizeof(float), sizeof(float) * 8);
-	printf("double:\t\t%2d (%3d bits)\n", sizeof(double), sizeof(double) * 8);
-	printf("long double:\t%2d (%3d bits)\n", sizeof(long double), sizeof(long double) * 8);
-	printf("\n");
-
-	printf("wchar_t:\t%2d (%3d bits)\n", sizeof(wchar_t), sizeof(wchar_t) * 8);
-	printf("size_t:\t\t%2d (%3d bits)\n", sizeof(size_t), sizeof(size_t) * 8);
-	printf("_Bool:\t\t%2d (%3d bits)\n", sizeof(_Bool), sizeof(_Bool) * 8);
-	printf("\n");
-
-	printf("int8_t:\t\t%2d (%3d bits)\n", sizeof(int8_t), sizeof(int8_t) * 8);
-	printf("int16_t:\t%2d (%3d bits)\n", sizeof(int16_t), sizeof(int16_t) * 8);
-	printf("int32_t:\t%2d (%3d bits)\n", sizeof(int32_t), sizeof(int32_t) * 8);
-	printf("int64_t:\t%2d (%3d bits)\n", sizeof(int64_t), sizeof(int64_t) * 8);
-#ifdef __LP64__
-	printf("__int128_t:\t%2d (%3d bits)\n", sizeof(__int128_t), sizeof(__int128_t) * 8);
-	printf("\n");
-#endif
-	printf("int_fast8_t:\t%2d (%3d bits)\n", sizeof(int_fast8_t), sizeof(int_fast8_t) * 8);
-	printf("int_fast16_t:\t%2d (%3d bits)\n", sizeof(int_fast16_t), sizeof(int_fast16_t) * 8);
-	printf("int_fast32_t:\t%2d (%3d bits)\n", sizeof(int_fast32_t), sizeof(int_fast32_t) * 8);
-	printf("int_fast64_t:\t%2d (%3d bits)\n", sizeof(int_fast64_t), sizeof(int_fast64_t) * 8);
-	printf("\n");
-	printf("int_least8_t:\t%2d (%3d bits)\n", sizeof(int_least8_t), sizeof(int_least8_t) * 8);
-	printf("int_least16_t:\t%2d (%3d bits)\n", sizeof(int_least16_t), sizeof(int_least16_t) * 8);
-	printf("int_least32_t:\t%2d (%3d bits)\n", sizeof(int_least32_t), sizeof(int_least32_t) * 8);
-	printf("int_least64_t:\t%2d (%3d bits)\n", sizeof(int_least64_t), sizeof(int_least64_t) * 8);
-	printf("\n");
-	printf("intmax_t:\t%2d (%3d bits)\n", sizeof(intmax_t), sizeof(intmax_t) * 8);
+/* Print the name and size of a type */
+static void
+print_type_size(char *type, size_t size) {
+	printf("%s:\t%2d (%3d bits)\n", type, size, size * CHAR_BIT);
 }
 
+int
+main() {
+	printf("\n");
+        printf("System: %d bit\n", sizeof(void*) * CHAR_BIT);
+
+	/* possible endian types */
+	printf("Host byte order: %s Endian\n", ENDIAN_TYPE);
+	printf("\n");
+
+	print_type_size("char\t",      sizeof(char));
+	print_type_size("short\t",     sizeof(short));
+	print_type_size("int\t",       sizeof(int));
+	print_type_size("long\t",      sizeof(long));
+	print_type_size("long long", sizeof(long long));
+	putchar('\n');
+
+	print_type_size("float\t",       sizeof(float));
+	print_type_size("double\t",      sizeof(double));
+	print_type_size("long double", sizeof(long double));
+	putchar('\n');
+
+	print_type_size("wchar_t", sizeof(wchar_t));
+	print_type_size("size_t\t",  sizeof(size_t));
+	print_type_size("_Bool\t",   sizeof(_Bool));
+	putchar('\n');
+
+	print_type_size("int8_t\t",  sizeof(int8_t));
+	print_type_size("int16_t", sizeof(int16_t));
+	print_type_size("int32_t", sizeof(int32_t));
+	print_type_size("int64_t", sizeof(int64_t));
+#ifdef __sizeof_int128__
+	print_type_size("__int128_t", sizeof(__int128_t));
+#endif
+	putchar('\n');
+
+	print_type_size("int_least8_t",  sizeof(int_fast8_t));
+	print_type_size("int_least16_t", sizeof(int_fast16_t));
+	print_type_size("int_least32_t", sizeof(int_fast32_t));
+	print_type_size("int_least64_t", sizeof(int_fast64_t));
+	putchar('\n');
+
+	print_type_size("int_fast8_t",  sizeof(int_fast8_t));
+	print_type_size("int_fast16_t", sizeof(int_fast16_t));
+	print_type_size("int_fast32_t", sizeof(int_fast32_t));
+	print_type_size("int_fast64_t", sizeof(int_fast64_t));
+	putchar('\n');
+
+	print_type_size("intmax_t", sizeof(intmax_t));
+	print_type_size("intptr_t", sizeof(intptr_t));
+}
 


### PR DESCRIPTION
This is a general PR to fix a couple bugs and improve the portability of `typecard`.

Here is a list of the changes:
* Use a function to print the size of types for better readability.
* Add `intptr_t` to the list of types printed.
* Use `CHAR_BIT` for bits-per-byte instead of the literal `8`.
* Calculate CPU bit-width using `sizeof(void*)` instead  of `__LP64__` to
allow for non-32/64-bit values.
* Add check for PDP Endianness.
* Use correct preprocessor macros to check for endianness and
presence of `__int128_t`.